### PR TITLE
Adds new route to fetch API News data

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "framer-motion": "^10.16.4",
         "moment-timezone": "^0.5.43",
         "mongodb": "^6.2.0",
-        "next": "14.0.2",
+        "newsapi": "^2.4.1",
+        "next": "^14.0.2",
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^4.11.0"
@@ -2452,6 +2453,16 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
+      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4361,6 +4372,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/newsapi": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/newsapi/-/newsapi-2.4.1.tgz",
+      "integrity": "sha512-yw/aZBgDwNbNMqQ1V7XFKdW2jvL8Fh4qMiU0Awin87Rt6lbPnS8OuiLaL15Ws5X82/EXhzNf/djAlPHOWVgMJg==",
+      "dependencies": {
+        "core-js": "^3.6.5",
+        "node-fetch": "^2.6.0"
+      }
+    },
     "node_modules/next": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/next/-/next-14.0.2.tgz",
@@ -4404,6 +4424,44 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "framer-motion": "^10.16.4",
     "moment-timezone": "^0.5.43",
     "mongodb": "^6.2.0",
-    "next": "14.0.2",
+    "newsapi": "^2.4.1",
+    "next": "^14.0.2",
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^4.11.0"

--- a/pages/api/external/newsApi.js
+++ b/pages/api/external/newsApi.js
@@ -1,0 +1,40 @@
+import NewsAPI from "newsapi";
+import { handleError, handleNewsResponse } from "../../../utils/errorHandler";
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    handleError(res, "Method Not Allowed");
+    return;
+  }
+
+  const apiKey = process.env.NEXT_PUBLIC_NEWS_API_KEY;
+
+  if (!apiKey) {
+    handleError(res, "Chave da API não configurada corretamente");
+    return;
+  }
+
+  try {
+    const newsApiResponse = await fetchNews(apiKey);
+    handleNewsResponse(res, newsApiResponse);
+  } catch (error) {
+    handleError(res, error.message);
+  }
+}
+
+const fetchNews = async (apiKey) => {
+  const newsapi = new NewsAPI(apiKey);
+
+  try {
+    const queryOptions = {
+      q: "Gremio OR Inter",
+      language: "pt",
+      sortBy: "relevancy",
+      domains:
+        "clicrbs.com.br, ge.globo.com/rs/futebol/times/gremio/, ge.globo.com/rs/futebol/times/internacional/",
+    };
+    return await newsapi.v2.everything(queryOptions);
+  } catch (error) {
+    throw new Error(`Erro na consulta à NewsAPI: ${error.message}`);
+  }
+};

--- a/utils/errorHandler.js
+++ b/utils/errorHandler.js
@@ -1,0 +1,12 @@
+export const handleError = (res, errorMessage) => {
+  res.status(500).json({ error: errorMessage });
+};
+
+export const handleNewsResponse = (res, newsApiResponse) => {
+  if (newsApiResponse.status === "ok") {
+    const newsArticles = newsApiResponse.articles;
+    res.status(200).json(newsArticles);
+  } else {
+    handleError(res, "Erro na consulta à NewsAPI");
+  }
+};


### PR DESCRIPTION
## Context

This PR aims to implement an API to fetch sports news from several brazilian local news (clicrbs, gauchazh and globoesporte) from `NewsAPI`, so we can render on sala de secacao website the most relevant news about Internacional and Gremio.

Changes: 
📦 chore(package.json): update next package version to ^14.0.2 and add newsapi package as a dependency
📝 feat(pages/api/external/newsApi.js): add API route to fetch news from NewsAPI and handle errors and responses
📝 feat(utils/errorHandler.js): add error handling functions to handle API errors and responses

How to access:
- Exposed through the route `/api/external/apiNews`
- Run `npm run dev`
- Access `http://localhost:3000/api/external/newsApi`

Results: 
![image](https://github.com/jonaszeferino/sala-two/assets/18623084/a638c81e-7647-4076-9306-ff0778e8e887)
